### PR TITLE
Changed numpy_type_map from class type to a function template

### DIFF
--- a/include/numpy_boost.hpp
+++ b/include/numpy_boost.hpp
@@ -42,59 +42,34 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/cstdint.hpp>
 #include <complex>
 #include <algorithm>
+#include <stdexcept>
 
 /* numpy_type_map<T>
 
    Provides a mapping from C++ datatypes to Numpy type
    numbers. */
 namespace detail {
-  template<class T>
-  class numpy_type_map {
-  public:
-    static const int typenum;
-  };
-
-  template<>
-  const int numpy_type_map<float>::typenum = NPY_FLOAT;
-
-  template<>
-  const int numpy_type_map<std::complex<float> >::typenum = NPY_CFLOAT;
-
-  template<>
-  const int numpy_type_map<double>::typenum = NPY_DOUBLE;
-
-  template<>
-  const int numpy_type_map<std::complex<double> >::typenum = NPY_CDOUBLE;
-
-  template<>
-  const int numpy_type_map<long double>::typenum = NPY_LONGDOUBLE;
-
-  template<>
-  const int numpy_type_map<std::complex<long double> >::typenum = NPY_CLONGDOUBLE;
-
-  template<>
-  const int numpy_type_map<boost::int8_t>::typenum = NPY_INT8;
-
-  template<>
-  const int numpy_type_map<boost::uint8_t>::typenum = NPY_UINT8;
-
-  template<>
-  const int numpy_type_map<boost::int16_t>::typenum = NPY_INT16;
-
-  template<>
-  const int numpy_type_map<boost::uint16_t>::typenum = NPY_UINT16;
-
-  template<>
-  const int numpy_type_map<boost::int32_t>::typenum = NPY_INT32;
-
-  template<>
-  const int numpy_type_map<boost::uint32_t>::typenum = NPY_UINT32;
-
-  template<>
-  const int numpy_type_map<boost::int64_t>::typenum = NPY_INT64;
-
-  template<>
-  const int numpy_type_map<boost::uint64_t>::typenum = NPY_UINT64;
+  template<typename T>
+  int numpy_type_map() {
+    throw std::runtime_error("numpy_type_map(): Illegal conversion requested");
+  }
+  
+  // Must be inlined to avoid multiple definitions since they are fully
+  // specialized function templates.
+  template<> inline int numpy_type_map<float>()                      { return NPY_FLOAT; }
+  template<> inline int numpy_type_map<std::complex<float> >()       { return NPY_CFLOAT; }
+  template<> inline int numpy_type_map<double>()                     { return NPY_DOUBLE; }
+  template<> inline int numpy_type_map<std::complex<double> >()      { return NPY_CDOUBLE; }
+  template<> inline int numpy_type_map<long double>()                { return NPY_LONGDOUBLE; }
+  template<> inline int numpy_type_map<std::complex<long double> >() { return NPY_CLONGDOUBLE; }
+  template<> inline int numpy_type_map<boost::int8_t>()              { return NPY_INT8; }
+  template<> inline int numpy_type_map<boost::uint8_t>()             { return NPY_UINT8; }
+  template<> inline int numpy_type_map<boost::int16_t>()             { return NPY_INT16; }
+  template<> inline int numpy_type_map<boost::uint16_t>()            { return NPY_UINT16; }
+  template<> inline int numpy_type_map<boost::int32_t>()             { return NPY_INT32; }
+  template<> inline int numpy_type_map<boost::uint32_t>()            { return NPY_UINT32; }
+  template<> inline int numpy_type_map<boost::int64_t>()             { return NPY_INT64; }
+  template<> inline int numpy_type_map<boost::uint64_t>()            { return NPY_UINT64; }
 }
 
 class python_exception : public std::exception {
@@ -190,7 +165,7 @@ public:
     PyArrayObject* a;
 
     a = (PyArrayObject*)PyArray_FromObject(
-        obj, ::detail::numpy_type_map<T>::typenum, NDims, NDims);
+        obj, ::detail::numpy_type_map<T>(), NDims, NDims);
     if (a == NULL) {
       throw boost::python::error_already_set();
     }
@@ -219,7 +194,7 @@ public:
     boost::detail::multi_array::copy_n(extents, NDims, shape);
 
     a = (PyArrayObject*)PyArray_SimpleNew(
-        NDims, shape, ::detail::numpy_type_map<T>::typenum);
+        NDims, shape, ::detail::numpy_type_map<T>());
     if (a == NULL) {
       throw boost::python::error_already_set();
     }

--- a/include/numpy_boost_python.hpp
+++ b/include/numpy_boost_python.hpp
@@ -73,7 +73,7 @@ struct numpy_boost_from_python
     PyArrayObject* a;
 
     a = (PyArrayObject*)PyArray_FromObject(
-        obj_ptr, ::detail::numpy_type_map<T>::typenum, NDims, NDims);
+        obj_ptr, ::detail::numpy_type_map<T>(), NDims, NDims);
     if (a == NULL) {
       return 0;
     }


### PR DESCRIPTION
Thank you for your nice library. This is a fix for making it succesfully compile with GCC on Linux.

I tried to compile a project which uses numpy-boost with GCC 4.8.2 and received "multiple definition" linker errors related to numpy_type_map. The problem was that the static const int member ended up being defined in multiple translation units as there were multiple .cpp files that included numpy_boost.hpp

I solved the problem by making numpy_type_map a function template instead. The function returns the int value and I made inline specializations of it for doing all the type conversion. The inlining solves the multiple definition issues. This solution works fine for me with both GCC and Visual Studio 2012.
